### PR TITLE
ci: build in Release mode and improve compilation with multi-threading

### DIFF
--- a/.github/actions/setup-deps/action.yml
+++ b/.github/actions/setup-deps/action.yml
@@ -1,8 +1,0 @@
-name: 'Set up dependencies'
-description: 'Set up the dependencies'
-runs:
-  using: 'composite'
-  steps:
-    - name: Install dependencies
-      run: sudo apt-get install libldap-common
-      shell: bash

--- a/.github/actions/setup-poetry/action.yml
+++ b/.github/actions/setup-poetry/action.yml
@@ -14,6 +14,6 @@ runs:
       with:
         python-version: ${{ inputs.python-version }}
         cache: 'poetry'
-    - name: Install dependencies
-      run: poetry install --all-extras
+    - name: Install only dependencies and not the package itself
+      run: poetry install --all-extras --no-root
       shell: bash

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,6 +1,9 @@
 on:
   workflow_call:
 
+env:
+  CMAKE_BUILD_TYPE: Debug
+
 jobs:
   run-checks:
     runs-on: ubuntu-latest
@@ -18,10 +21,9 @@ jobs:
       - name: Run styling check
         run: poetry run pre-commit run --all-files
       - name: Install with poetry
-        run: poetry install
+        run: poetry install --all-extras
       - name: Testing
         run: |
           poetry run pytest -v tests
       - name: Build with poetry
         run: poetry build
-  

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ on:
 env:
   # disable keyring (https://github.com/actions/runner-images/issues/6185):
   PYTHON_KEYRING_BACKEND: keyring.backends.null.Keyring
-  BUILD_TYPE: Release
 
 jobs:
   code-checks:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,6 +1,9 @@
 on:
   workflow_call:
 
+env:
+  CMAKE_BUILD_TYPE: Release
+
 jobs:
   build_wheels:
     name: Build wheel for py${{ matrix.python-version }} ${{ matrix.os.platform_id }} ${{ matrix.os.macos_version }}
@@ -47,11 +50,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      # - name: Install dependencies [linux]
-      #   if: matrix.os.platform == 'linux'
-      #   run: sudo apt-get install -y libldap-common
-      #   shell: bash
-
       - name: Install poetry
         run: pipx install poetry==1.8.3 --python $(which python3)
         shell: bash
@@ -86,6 +84,7 @@ jobs:
           CIBW_REPAIR_WHEEL_COMMAND_MACOS: ""  # do not run delocate-wheel before the re-tag
           CIBW_ENVIRONMENT: "MACOSX_DEPLOYMENT_TARGET=${{ matrix.os.macos_version }}.0"
           ARCHFLAGS: -arch x86_64
+          BUILD_THREADS: "4"
         run: |
           echo "Building wheel ${CIBW_BUILD}"
           poetry run python --version
@@ -122,6 +121,7 @@ jobs:
           CIBW_REPAIR_WHEEL_COMMAND_MACOS: ""  # do not run delocate-wheel before the re-tag
           CIBW_ENVIRONMENT: "MACOSX_DEPLOYMENT_TARGET=${{ matrix.os.macos_version }}.0"
           ARCHFLAGS: -arch arm64
+          BUILD_THREADS: "4"
         run: |
           echo "Building wheel ${CIBW_BUILD}"
           poetry run python --version
@@ -164,6 +164,7 @@ jobs:
           CIBW_SKIP: "pp* *musllinux_* *_i686* *_s390*"
           CIBW_PROJECT_REQUIRES_PYTHON: ">=3.8"
           CIBW_BUILD_VERBOSITY: 3
+          BUILD_THREADS: "8"
         run: |
           echo "Building wheel ${CIBW_BUILD}"
           poetry run python --version

--- a/build.py
+++ b/build.py
@@ -25,7 +25,7 @@ def run(cmd, cwd="./"):
     return False
 
 
-def build_local(multi_threaded=True):
+def build_local(num_threads: int):
 
     if not os.path.exists(BUILD_DIR):
         print("python executable: ", sys.executable)
@@ -38,13 +38,13 @@ def build_local(multi_threaded=True):
         print(f"build directory detected: {BUILD_DIR}")
 
     cmd = f"cmake --build {BUILD_DIR} --target install"
-    if multi_threaded:
-        cmd += " -j 4"
+    if num_threads > 1:
+        cmd += f" -j {num_threads}"
     success = run(cmd, cwd=ROOT_DIR)
     if not success:
         raise RuntimeError("Error building.")
 
 
 if "__main__" == __name__:
-
-    build_local(multi_threaded=False)
+    num_threads = int(os.getenv("BUILD_THREADS", "4"))
+    build_local(num_threads=num_threads)


### PR DESCRIPTION
- Set `CMAKE_BUILD_TYPE=Release`
- Avoid building twice the code from setup-poetry
- Control the number of threads for building via ENV