### PR TITLE
Fix cmake segfault by renaming ext_name_cxxopts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,7 +109,7 @@ include(cmake/extlib_jpeg.cmake)
 include(cmake/extlib_qpdf_v11.cmake)
 
 # aggregate the targets created by the dependencies
-set(DEPENDENCIES qpdf jpeg utf8 json loguru cxxopts)
+set(DEPENDENCIES qpdf jpeg utf8 json loguru ext_cxxopts)
 
 # ************************
 # *** libraries        ***

--- a/cmake/extlib_cxxopts.cmake
+++ b/cmake/extlib_cxxopts.cmake
@@ -1,7 +1,7 @@
 
 message(STATUS "entering in extlib_cxxopts.cmake")
 
-set(ext_name_cxxopts "cxxopts")
+set(ext_name_cxxopts "ext_cxxopts")
 
 if(USE_SYSTEM_DEPS)
     message(STATUS "using system-deps in extlib_cxxopts.cmake")


### PR DESCRIPTION
Our builds are failing with a segfault with cmake 3.26.5 on RHEL. The final phase of CMake is trapped in an infinitive recursion and eventually exhausts all stack trace. The segfault only occurs with `USE_SYSTEM_DEPS=ON`.

Eventually we found the culprit in `extlib_cxxopts.cmake`. The line `add_dependencies(${ext_name_cxxopts} cxxopts)` is causing the segfault. `ext_name_cxxopts` is `cxxopts`. I'm not entirely sure why it is failing. I think there is a variable name clash. Setting `ext_name_cxxopts` to a different value resolves the problem.