### PR TITLE
Fix `build_rhel.sh` to create isolated build

### DIFF
--- a/.github/scripts/build_rhel.sh
+++ b/.github/scripts/build_rhel.sh
@@ -6,8 +6,6 @@ set -x  # display command on output
 # Build the Python package with Poetry
 poetry build -f sdist
 
-USE_SYSTEM_DEPS="ON"
-
 docker build --progress=plain \
              --build-arg USE_SYSTEM_DEPS="$USE_SYSTEM_DEPS" \
              -f - . <<EOF
@@ -15,38 +13,37 @@ docker build --progress=plain \
 
     FROM quay.io/centos/centos:stream9
 
-    RUN dnf config-manager --set-enabled crb
-    
-    RUN dnf copr -y enable cheimes/deepsearch-glm rhel-9-x86_64
-
-    RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm \
-       && dnf clean all
+    RUN dnf update -y \
+        && dnf install -y 'dnf-command(config-manager)' 'dnf-command(copr)' \
+        && dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm \
+        && dnf copr -y enable cheimes/deepsearch-glm rhel-9-x86_64 \
+        && crb enable \
+        && dnf clean all
 
     RUN dnf install -y --nodocs \
             autoconf automake binutils cmake gcc gcc-c++ git glibc-devel glibc-headers glibc-static kernel-devel libtool libstdc++-devel make ninja-build pkgconfig zlib-devel \
             python3.11 python3.11-pip python3.11-devel \
-            libjpeg-turbo-devel libpng-devel qpdf-devel json-devel utf8cpp-devel \
+            libjpeg-turbo-devel libpng-devel qpdf-devel json-devel utf8cpp-devel loguru-devel cxxopts-devel \
         && dnf clean all
 
-    # # RUN dnf install -y --nodocs loguru-devel
+    WORKDIR /src
 
-    # TEMPORARY loguru install method
-    # https://koji.fedoraproject.org/koji/buildinfo?buildID=2563067
-    RUN curl -O https://kojipkgs.fedoraproject.org//packages/loguru/2.2.0%5E20230406git4adaa18/5.el9/x86_64/loguru-2.2.0%5E20230406git4adaa18-5.el9.x86_64.rpm
-    RUN dnf install -y loguru-2.2.0%5E20230406git4adaa18-5.el9.x86_64.rpm
-    RUN curl -O https://kojipkgs.fedoraproject.org//packages/loguru/2.2.0%5E20230406git4adaa18/5.el9/x86_64/loguru-devel-2.2.0%5E20230406git4adaa18-5.el9.x86_64.rpm
-    RUN dnf install -y loguru-devel-2.2.0%5E20230406git4adaa18-5.el9.x86_64.rpm
+    COPY ./dist/*.tar.gz .
 
-    RUN mkdir /src
+    ENV USE_SYSTEM_DEPS=on
 
-    COPY ./dist/*.tar.gz /src/
-
-    RUN USE_SYSTEM_DEPS=\$USE_SYSTEM_DEPS pip3.11 install /src/docling_parse*.tar.gz \
+    # pre-install build requirements + wheel for "--no-build-isolation"
+    # build docling-parse wheel in an isolated network namespace (unshare -rn)
+    # install the wheel and its dependencies
+    RUN pip3.11 install poetry-core pybind11 wheel \
+        && unshare -rn pip3.11 wheel \
+            --no-deps --no-build-isolation -w /dist/ \
+            /src/docling_parse*.tar.gz \
+        && pip3.11 install /dist/docling_parse*.whl \
         && python3.11 -c 'from docling_parse.docling_parse import pdf_parser, pdf_parser_v2'
     
     COPY ./tests /src/tests
 
-    RUN cd /src \
-        && pip3.11 install pytest \
+    RUN pip3.11 install pytest \
         && pytest
 EOF


### PR DESCRIPTION
- install DNF plugins for copr and config manager
- install missing `cxxopts-devel`
- install `loguru-devel` from EPEL 9. The update has landed two days ago.
- move `USE_SYSTEM_DEPS` into container file to address a backslash escape problem
- build the wheel in an isolated network namespace with `unshare -rn`. Since the build step is longer able to install its build dependencies, we have to pre-install the packages and use `--no-build-isolation`.

Tests will now fail with a segfault in `cmake` until #44 has landed.