### PR TITLE
chore: CD on demand and mergify checks

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,9 @@
+merge_protections:
+  - name: Enforce conventional commit
+    description: Make sure that we follow https://www.conventionalcommits.org/en/v1.0.0/
+    if:
+      - base = main
+    success_conditions:
+      - "title ~=
+        ^(fix|feat|docs|style|refactor|perf|test|build|ci|chore|revert)(?:\\(.+\
+        \\))?:"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,9 +1,7 @@
 name: "Run CD"
 
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
 
 env:
   # disable keyring (https://github.com/actions/runner-images/issues/6185):


### PR DESCRIPTION
- Moves CD pipeline on-demand (as in other Docling repos)
- Add mergify with pr title checks