### PR TITLE
ci: add upload to build artifacts and push once together to pypi

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
   build-wheels:
     if: ${{ github.event_name == 'push' || (github.event.pull_request.head.repo.full_name != 'DS4SD/docling-parse' && github.event.pull_request.head.repo.full_name != 'ds4sd/docling-parse') }}
     uses: ./.github/workflows/wheels.yml
+    permissions:
+      id-token: write  # needed also if not used (see publish condition)
+      contents: write  # needed also if not used (see publish condition)
   rhel-build:
     if: ${{ github.event_name == 'push' || (github.event.pull_request.head.repo.full_name != 'DS4SD/docling-parse' && github.event.pull_request.head.repo.full_name != 'ds4sd/docling-parse') }}
     uses: ./.github/workflows/rhel.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,6 @@ jobs:
   build-wheels:
     if: ${{ github.event_name == 'push' || (github.event.pull_request.head.repo.full_name != 'DS4SD/docling-parse' && github.event.pull_request.head.repo.full_name != 'ds4sd/docling-parse') }}
     uses: ./.github/workflows/wheels.yml
-    permissions:
-      id-token: write  # IMPORTANT: mandatory for trusted publishing
   rhel-build:
     if: ${{ github.event_name == 'push' || (github.event.pull_request.head.repo.full_name != 'DS4SD/docling-parse' && github.event.pull_request.head.repo.full_name != 'ds4sd/docling-parse') }}
     uses: ./.github/workflows/rhel.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
   build-wheels:
     if: ${{ github.event_name == 'push' || (github.event.pull_request.head.repo.full_name != 'DS4SD/docling-parse' && github.event.pull_request.head.repo.full_name != 'ds4sd/docling-parse') }}
     uses: ./.github/workflows/wheels.yml
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
   rhel-build:
     if: ${{ github.event_name == 'push' || (github.event.pull_request.head.repo.full_name != 'DS4SD/docling-parse' && github.event.pull_request.head.repo.full_name != 'ds4sd/docling-parse') }}
     uses: ./.github/workflows/rhel.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,8 @@ permissions:
 jobs:
   build-and-publish:
     uses: ./.github/workflows/wheels.yml
+    with:
+      publish: true
     secrets: inherit
     permissions:
       id-token: write  # IMPORTANT: mandatory for trusted publishing

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,3 +11,6 @@ jobs:
   build-and-publish:
     uses: ./.github/workflows/wheels.yml
     secrets: inherit
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+      contents: write  # IMPORTANT: mandatory for adding artifacts to GitHub Releases

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -318,7 +318,7 @@ jobs:
           path: dist/
 
 
-  publish-to-pypi-test:
+  list-artifacts:
     name: >-
       TEMP test created wheels
     needs:
@@ -336,7 +336,36 @@ jobs:
         run: |
           ls -l
           ls -l ./dist
-        
+
+  publish-to-pypi-test:
+    name: >-
+      Publish Python 🐍 distribution 📦 to PyPI
+    if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
+    needs:
+      - build_sdist
+      - build_wheels
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/docling-parse
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+          path: dist/
+      - name: List dist/
+        run: |
+          ls ./dist
+      - name: Publish distribution 📦 to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+  
+
   publish-to-pypi:
     name: >-
       Publish Python 🐍 distribution 📦 to PyPI
@@ -347,7 +376,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: pypi
-      url: https://pypi.org/p/docling
+      url: https://pypi.org/p/docling-parse
     # permissions:
     #   id-token: write  # IMPORTANT: mandatory for trusted publishing
 
@@ -356,6 +385,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           merge-multiple: true
+          path: dist/
       - name: List dist/
         run: |
           ls ./dist

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -1,5 +1,10 @@
 on:
   workflow_call:
+    inputs:
+      publish:
+        type: boolean
+        description: "If true, the packages will be published."
+        default: false
 
 env:
   CMAKE_BUILD_TYPE: Release
@@ -304,7 +309,7 @@ jobs:
   publish-packages:
     name: >-
       Publish Python 🐍 distribution 📦 to PyPI
-    if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
+    if: inputs.publish && startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
     needs:
       - build_sdist
       - build_wheels

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -101,12 +101,6 @@ jobs:
           $cp_version = "cp$($version -replace '\.', '')"
           Add-Content -Path $env:GITHUB_ENV -Value "python_cp_version=$cp_version"
 
-      # - name: Setup pypi for poetry [for releases only]
-      #   if: ${{ startsWith(github.ref, 'refs/tags/') }}
-      #   run: |
-      #     poetry config keyring.enabled false
-      #     poetry config pypi-token.pypi ${{ secrets.PYPI_TOKEN }}
-
       - name: Convert python version to cpXYZ
         if: ${{matrix.os.platform_id != 'win_amd64'}}
         run: |
@@ -317,39 +311,20 @@ jobs:
           name: python-package-distributions-py${{ matrix.python-version }}-${{ matrix.os.name }}-${{ matrix.os.platform_id }}
           path: dist/
 
-
-  list-artifacts:
+  publish-packages:
     name: >-
-      TEMP test created wheels
-    needs:
-      - build_sdist
-      - build_wheels
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Download all the dists
-        uses: actions/download-artifact@v4
-        with:
-          merge-multiple: true
-          path: dist/
-      - name: List dist/
-        run: |
-          ls -l
-          ls -l ./dist
-
-  publish-to-pypi-test:
-    name: >-
-      Publish Python 🐍 distribution 📦 to TEST PyPI
+      Publish Python 🐍 distribution 📦 to PyPI
+    if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
     needs:
       - build_sdist
       - build_wheels
     runs-on: ubuntu-latest
     environment:
-      name: testpypi
-      url: https://test.pypi.org/p/docling-parse
+      name: pypi
+      url: https://pypi.org/p/docling-parse
     permissions:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
-
+      contents: write  # IMPORTANT: mandatory for adding artifacts to GitHub Releases
     steps:
       - name: Download all the dists
         uses: actions/download-artifact@v4
@@ -369,61 +344,22 @@ jobs:
       - name: List dist/
         run: |
           ls ./dist
-      # - name: Upload artifact signatures to GitHub Release
-      #   env:
-      #     GITHUB_TOKEN: ${{ github.token }}
-      #   # Upload to GitHub Release using the `gh` CLI.
-      #   # `dist/` contains the built packages, and the
-      #   # sigstore-produced signatures and certificates.
-      #   run: >-
-      #     gh release upload
-      #     '${{ github.ref_name }}' dist/**
-      #     --repo '${{ github.repository }}'
-
+      - name: Upload artifact signatures to GitHub Release
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        # Upload to GitHub Release using the `gh` CLI.
+        # `dist/` contains the built packages, and the
+        # sigstore-produced signatures and certificates.
+        run: >-
+          gh release upload
+          '${{ github.ref_name }}' dist/**
+          --repo '${{ github.repository }}'
       # PyPI does not accept .sigstore artifacts and
       # gh-action-pypi-publish has no option to ignore them.
       - name: Remove sigstore signatures before uploading to PyPI
         run: rm ./dist/*.sigstore.json
-
       - name: Publish distribution 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
+          # currently not working with reusable workflows
           attestations: false
-          repository-url: https://test.pypi.org/legacy/
-
-  publish-to-pypi:
-    name: >-
-      Publish Python 🐍 distribution 📦 to PyPI
-    if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
-    needs:
-      - build_sdist
-      - build_wheels
-    runs-on: ubuntu-latest
-    environment:
-      name: pypi
-      url: https://pypi.org/p/docling-parse
-    # permissions:
-    #   id-token: write  # IMPORTANT: mandatory for trusted publishing
-
-    steps:
-      - name: Download all the dists
-        uses: actions/download-artifact@v4
-        with:
-          merge-multiple: true
-          path: dist/
-      - name: List dist/
-        run: |
-          ls ./dist
-      - name: Publish distribution 📦 to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_TOKEN }}
-
-        # - name: publish wheels (dry run)
-        #   run: |
-        #     poetry publish --skip-existing --dry-run --no-interaction -vvv
-
-        # - name: publish wheels (on publishing) [for releases only]
-        #   if: ${{ startsWith(github.ref, 'refs/tags/') }}
-        #   run: |
-        #     poetry publish --skip-existing --no-interaction -vvv

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -339,8 +339,7 @@ jobs:
 
   publish-to-pypi-test:
     name: >-
-      Publish Python 🐍 distribution 📦 to PyPI
-    if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
+      Publish Python 🐍 distribution 📦 to TEST PyPI
     needs:
       - build_sdist
       - build_wheels

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -360,11 +360,35 @@ jobs:
       - name: List dist/
         run: |
           ls ./dist
+      - name: Sign the dists with Sigstore
+        uses: sigstore/gh-action-sigstore-python@v3.0.0
+        with:
+          inputs: >-
+            ./dist/*.tar.gz
+            ./dist/*.whl
+      - name: List dist/
+        run: |
+          ls ./dist
+      # - name: Upload artifact signatures to GitHub Release
+      #   env:
+      #     GITHUB_TOKEN: ${{ github.token }}
+      #   # Upload to GitHub Release using the `gh` CLI.
+      #   # `dist/` contains the built packages, and the
+      #   # sigstore-produced signatures and certificates.
+      #   run: >-
+      #     gh release upload
+      #     '${{ github.ref_name }}' dist/**
+      #     --repo '${{ github.repository }}'
+
+      # PyPI does not accept .sigstore artifacts and
+      # gh-action-pypi-publish has no option to ignore them.
+      - name: Remove sigstore signatures before uploading to PyPI
+        run: rm ./dist/*.sigstore.json
+
       - name: Publish distribution 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
-  
 
   publish-to-pypi:
     name: >-

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -362,6 +362,7 @@ jobs:
       - name: Sign the dists with Sigstore
         uses: sigstore/gh-action-sigstore-python@v3.0.0
         with:
+          release-signing-artifacts: false
           inputs: >-
             ./dist/*.tar.gz
             ./dist/*.whl

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -3,8 +3,31 @@ on:
 
 env:
   CMAKE_BUILD_TYPE: Release
+  POETRY_VERSION: "1.8.4"
 
 jobs:
+  build_sdist:
+    name: Build sdist artifacts
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+      - name: Install poetry
+        run: |
+          pipx install poetry==$POETRY_VERSION
+      - name: Build sdit
+        run: |
+          poetry build -f sdist
+          ls ./dist
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+
   build_wheels:
     name: Build wheel for py${{ matrix.python-version }} ${{ matrix.os.platform_id }} ${{ matrix.os.macos_version }}
     runs-on: ${{ matrix.os.name }}
@@ -64,7 +87,7 @@ jobs:
           python3 --version
           echo "pythonpath: ${{ steps.py.outputs.python-path }}"
           ${{ steps.py.outputs.python-path }} --version
-          pipx install poetry==1.8.4
+          pipx install poetry==$POETRY_VERSION
           poetry env use ${{ steps.py.outputs.python-path }}
 
       - name: Set up custom PATH and set py version to cpXYZ [windows]
@@ -79,11 +102,11 @@ jobs:
           $cp_version = "cp$($version -replace '\.', '')"
           Add-Content -Path $env:GITHUB_ENV -Value "python_cp_version=$cp_version"
 
-      - name: Setup pypi for poetry [for releases only]
-        if: ${{ startsWith(github.ref, 'refs/tags/') }}
-        run: |
-          poetry config keyring.enabled false
-          poetry config pypi-token.pypi ${{ secrets.PYPI_TOKEN }}
+      # - name: Setup pypi for poetry [for releases only]
+      #   if: ${{ startsWith(github.ref, 'refs/tags/') }}
+      #   run: |
+      #     poetry config keyring.enabled false
+      #     poetry config pypi-token.pypi ${{ secrets.PYPI_TOKEN }}
 
       - name: Convert python version to cpXYZ
         if: ${{matrix.os.platform_id != 'win_amd64'}}
@@ -296,11 +319,46 @@ jobs:
           }
           Copy-Item -Path .\wheelhouse\*.whl -Destination .\dist\
 
-      - name: publish wheels (dry run)
-        run: |
-          poetry publish --skip-existing --dry-run --no-interaction -vvv
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
 
-      - name: publish wheels (on publishing) [for releases only]
-        if: ${{ startsWith(github.ref, 'refs/tags/') }}
+
+  publish-to-pypi:
+    name: >-
+      Publish Python 🐍 distribution 📦 to PyPI
+    if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
+    needs:
+      - build_sdist
+      - build_wheels
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/docling
+    # permissions:
+    #   id-token: write  # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
+      - name: List dist/
         run: |
-          poetry publish --skip-existing --no-interaction -vvv
+          ls ./dist
+      - name: Publish distribution 📦 to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_TOKEN }}
+
+        # - name: publish wheels (dry run)
+        #   run: |
+        #     poetry publish --skip-existing --dry-run --no-interaction -vvv
+
+        # - name: publish wheels (on publishing) [for releases only]
+        #   if: ${{ startsWith(github.ref, 'refs/tags/') }}
+        #   run: |
+        #     poetry publish --skip-existing --no-interaction -vvv

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -331,9 +331,11 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           merge-multiple: true
+          path: dist/
       - name: List dist/
         run: |
-          ls ./dist
+          ls -l
+          ls -l ./dist
         
   publish-to-pypi:
     name: >-

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -388,6 +388,7 @@ jobs:
       - name: Publish distribution 📦 to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
+          attestations: false
           repository-url: https://test.pypi.org/legacy/
 
   publish-to-pypi:

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -3,7 +3,6 @@ on:
 
 env:
   CMAKE_BUILD_TYPE: Release
-  POETRY_VERSION: "1.8.4"
 
 jobs:
   build_sdist:
@@ -17,7 +16,7 @@ jobs:
         uses: actions/setup-python@v5
       - name: Install poetry
         run: |
-          pipx install poetry==$POETRY_VERSION
+          pipx install poetry
       - name: Build sdit
         run: |
           poetry build -f sdist
@@ -25,7 +24,7 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: python-package-distributions
+          name: python-package-distributions-sdist
           path: dist/
 
   build_wheels:
@@ -87,7 +86,7 @@ jobs:
           python3 --version
           echo "pythonpath: ${{ steps.py.outputs.python-path }}"
           ${{ steps.py.outputs.python-path }} --version
-          pipx install poetry==$POETRY_VERSION
+          pipx install poetry==1.8.4
           poetry env use ${{ steps.py.outputs.python-path }}
 
       - name: Set up custom PATH and set py version to cpXYZ [windows]
@@ -218,13 +217,6 @@ jobs:
         uses: docker/setup-qemu-action@v3
         with:
             platforms: all
-
-      - name: Build sdist
-        # build only on Linux to avoid too many duplicates of the sdist
-        if: matrix.os.name == 'ubuntu-latest' 
-        run: |
-          echo "Building wheel ${CIBW_BUILD}"
-          poetry build -f sdist
         
       - name: Build wheels [linux]
         if: matrix.os.name == 'ubuntu-latest'
@@ -322,10 +314,27 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: python-package-distributions
+          name: python-package-distributions-py${{ matrix.python-version }}-${{ matrix.os.name }}-${{ matrix.os.platform_id }}
           path: dist/
 
 
+  publish-to-pypi-test:
+    name: >-
+      TEMP test created wheels
+    needs:
+      - build_sdist
+      - build_wheels
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download all the dists
+        uses: actions/download-artifact@v4
+        with:
+          merge-multiple: true
+      - name: List dist/
+        run: |
+          ls ./dist
+        
   publish-to-pypi:
     name: >-
       Publish Python 🐍 distribution 📦 to PyPI
@@ -344,8 +353,7 @@ jobs:
       - name: Download all the dists
         uses: actions/download-artifact@v4
         with:
-          name: python-package-distributions
-          path: dist/
+          merge-multiple: true
       - name: List dist/
         run: |
           ls ./dist

--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -28,7 +28,7 @@ jobs:
           path: dist/
 
   build_wheels:
-    name: Build wheel for py${{ matrix.python-version }} ${{ matrix.os.platform_id }} ${{ matrix.os.macos_version }}
+    name: Build wheel for py${{ matrix.python-version }} ${{ matrix.os.platform_id }}
     runs-on: ${{ matrix.os.name }}
 
     strategy:
@@ -45,22 +45,12 @@ jobs:
 
           - name: "macos-13"
             platform: "macos"
-            macos_version: "13"
-            platform_id: "macosx_x86_64"
-
-          - name: "macos-13"
-            platform: "macos"
-            macos_version: "13"
-            platform_id: "macosx_arm64"
-
-          - name: "macos-14"
-            platform: "macos"
-            macos_version: "14"
+            min_macos_version: "13"
             platform_id: "macosx_x86_64"
 
           - name: "macos-14"
             platform: "macos"
-            macos_version: "14"
+            min_macos_version: "14"
             platform_id: "macosx_arm64"
 
           - name: "windows-latest"
@@ -120,7 +110,7 @@ jobs:
           CIBW_BUILD_VERBOSITY: 3
           CMAKE_OSX_ARCHITECTURES: x86_64
           CIBW_REPAIR_WHEEL_COMMAND_MACOS: ""  # do not run delocate-wheel before the re-tag
-          CIBW_ENVIRONMENT: "MACOSX_DEPLOYMENT_TARGET=${{ matrix.os.macos_version }}.0"
+          CIBW_ENVIRONMENT: "MACOSX_DEPLOYMENT_TARGET=${{ matrix.os.min_macos_version }}.0"
           ARCHFLAGS: -arch x86_64
           BUILD_THREADS: "4"
           PYTORCH_MPS_HIGH_WATERMARK_RATIO: "0.0"
@@ -137,7 +127,7 @@ jobs:
           poetry run python -m cibuildwheel --output-dir wheelhouse
           echo "step 1"
           ls -l wheelhouse
-          poetry run wheel tags --platform-tag macosx_${{ matrix.os.macos_version }}_0_x86_64 ./wheelhouse/*.whl
+          poetry run wheel tags --remove --platform-tag macosx_${{ matrix.os.min_macos_version }}_0_x86_64 ./wheelhouse/*.whl
           rm -f ./wheelhouse/*arm64.whl
           echo "step 2"
           ls -l wheelhouse
@@ -170,7 +160,7 @@ jobs:
           CIBW_BUILD_VERBOSITY: 3
           CMAKE_OSX_ARCHITECTURES: arm64
           CIBW_REPAIR_WHEEL_COMMAND_MACOS: ""  # do not run delocate-wheel before the re-tag
-          CIBW_ENVIRONMENT: "MACOSX_DEPLOYMENT_TARGET=${{ matrix.os.macos_version }}.0"
+          CIBW_ENVIRONMENT: "MACOSX_DEPLOYMENT_TARGET=${{ matrix.os.min_macos_version }}.0"
           ARCHFLAGS: -arch arm64
           BUILD_THREADS: "4"
           PYTORCH_MPS_HIGH_WATERMARK_RATIO: "0.0"
@@ -188,7 +178,7 @@ jobs:
           poetry run python -m cibuildwheel --output-dir wheelhouse
           echo "step 1"
           ls -l wheelhouse
-          poetry run wheel tags --platform-tag macosx_${{ matrix.os.macos_version }}_0_arm64 ./wheelhouse/*.whl
+          poetry run wheel tags --remove --platform-tag macosx_${{ matrix.os.min_macos_version }}_0_arm64 ./wheelhouse/*.whl
           rm -f ./wheelhouse/*x86_64.whl
           echo "step 2"
           ls -l wheelhouse
@@ -308,7 +298,7 @@ jobs:
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: python-package-distributions-py${{ matrix.python-version }}-${{ matrix.os.name }}-${{ matrix.os.platform_id }}
+          name: python-package-distributions-py${{ matrix.python-version }}-${{ matrix.os.platform_id }}
           path: dist/
 
   publish-packages:


### PR DESCRIPTION
Resolves #67.
Resolves #68.

In this PR we apply the following changes
1. Packages are first saved in the CI build artifacts, and then pushed to pypi all together.
    - these wheels will be saved also in PRs, so we can download them and try locally
3. We use the new pypi trusted publishers option for pushing to pypi
4. Packages are signed and published also as the GH release attachments
5. Mac releases now support 10.13+ with a single wheel