### PR TITLE
docs: fixed broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Install the package from Pypi
 pip install docling-parse
 ```
 
-Convert a PDF (look in the [visualise.py](docling_parse/visualise.py) for a more detailed information)
+Convert a PDF (look in the [visualize.py](docling_parse/visualize.py) for a more detailed information)
 
 ```python
 from docling_parse.docling_parse import pdf_parser_v2


### PR DESCRIPTION
Just a small change from [visualise.py](https://github.com/DS4SD/docling-parse/blob/main/docling_parse/visualise.py) to [visualize.py](https://github.com/DS4SD/docling-parse/blob/main/docling_parse/visualize.py) to fix the broken link